### PR TITLE
Integrate comments from review

### DIFF
--- a/build-latex.sh
+++ b/build-latex.sh
@@ -1,0 +1,11 @@
+#! /bin/bash
+set -e
+python3 -m venv .venv
+. .venv/bin/activate
+pip install -U pip
+pip install -Ur paper-requirements.txt
+jupyter nbconvert --ClearOutputPreprocessor.enabled=True --inplace paper.ipynb
+jupyter nbconvert --execute --to notebook --inplace paper.ipynb
+jupyter nbconvert paper.ipynb --TagRemovePreprocessor.remove_cell_tags='html_only' --TagRemovePreprocessor.remove_cell_tags='no_latex' --TagRemovePreprocessor.remove_input_tags='latex_only' --to latex --template ./templates/latex --output-dir _site --output index
+jupyter nbconvert --ClearOutputPreprocessor.enabled=True --inplace paper.ipynb
+cp paper.bib _site/

--- a/paper.bib
+++ b/paper.bib
@@ -40,6 +40,15 @@ isbn="978-3-319-76578-5"
   pages={4--13},
   year={2019}
 }
+@article{althobaiti2021quantum,
+  title={Quantum-resistant cryptography for the Internet of Things based on location-based lattices},
+  author={Althobaiti, Ohood Saud and Dohler, Mischa},
+  journal={IEEE Access},
+  volume={9},
+  pages={133185--133203},
+  year={2021},
+  publisher={IEEE}
+}
 @article{arute2019quantum,
   title={Quantum supremacy using a programmable superconducting processor},
   author={Arute, Frank and Arya, Kunal and Babbush, Ryan and Bacon, Dave and Bardin, Joseph C and Barends, Rami and Biswas, Rupak and Boixo, Sergio and Brandao, Fernando GSL and Buell, David A and others},
@@ -66,6 +75,12 @@ isbn="978-3-319-76578-5"
   booktitle={Proceedings of the 2019 ACM SIGSAC conference on computer and communications security},
   pages={2129--2146},
   year={2019}
+}
+@misc{biden2022national,
+  title={{National Security Memorandum on Promoting United States Leadership in Quantum Computing While Mitigating Risks to Vulnerable Cryptographic Systems}},
+  author={Joseph R. Biden},
+  year={2022},
+  publisher={{The White House}}
 }
 @inproceedings{bos2015post,
   title={{Post-quantum key exchange for the TLS protocol from the ring learning with errors problem}},
@@ -170,6 +185,12 @@ isbn="978-3-319-76578-5"
   title={{Swoosh: Practical Lattice-Based Non-Interactive Key Exchange}},
   author={Gajland, Phillip and de Kock, Bor and Quaresma, Miguel and Malavolta, Giulio and Schwabe, Peter},
   journal={{Cryptology ePrint Archive}},
+  year={2023}
+}
+@article{giron2023migrating,
+  title={Migrating Applications to Post-Quantum Cryptography: Beyond Algorithm Replacement},
+  author={Giron, Alexandre Augusto},
+  journal={Cryptology ePrint Archive},
   year={2023}
 }
 @inproceedings{grover1996fast,
@@ -295,6 +316,12 @@ isbn="978-3-319-76578-5"
   journal={{arXiv preprint arXiv:1909.07353}},
   year={2019}
 }
+@article{parker2023estimating,
+  title={Estimating the Energy Requirements to Operate a Cryptanalytically Relevant Quantum Computer},
+  author={Parker, Edward and Vermeer, Michael JD},
+  journal={arXiv preprint arXiv:2304.14344},
+  year={2023}
+}
 @article{prest2020falcon,
   title={Falcon},
   author={Prest, Thomas and Fouque, Pierre-Alain and Hoffstein, Jeffrey and Kirchner, Paul and Lyubashevsky, Vadim and Pornin, Thomas and Ricosset, Thomas and Seiler, Gregor and Whyte, William and Zhang, Zhenfei},
@@ -350,4 +377,9 @@ isbn="978-3-319-76578-5"
   author={Ylonen, Tatu},
   year={2006},
   publisher={{RFC Editor}}
+}
+@misc{mattsson2022quantum,
+  title={{Quantum-Resistance Cryptography}},
+  author={John Preuß Mattsson, Ben Smeets, abd Eric Thormarker},
+  publisher={Ericsson Security Research}
 }

--- a/paper.ipynb
+++ b/paper.ipynb
@@ -5,10 +5,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-09-04T20:55:29.406588Z",
-     "iopub.status.busy": "2023-09-04T20:55:29.405942Z",
-     "iopub.status.idle": "2023-09-04T20:55:29.414013Z",
-     "shell.execute_reply": "2023-09-04T20:55:29.413158Z"
+     "iopub.execute_input": "2023-09-16T19:20:19.598246Z",
+     "iopub.status.busy": "2023-09-16T19:20:19.598104Z",
+     "iopub.status.idle": "2023-09-16T19:20:19.606929Z",
+     "shell.execute_reply": "2023-09-16T19:20:19.606498Z"
     },
     "tags": [
      "html_only"
@@ -34,10 +34,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-09-04T20:55:29.437912Z",
-     "iopub.status.busy": "2023-09-04T20:55:29.437682Z",
-     "iopub.status.idle": "2023-09-04T20:55:29.442394Z",
-     "shell.execute_reply": "2023-09-04T20:55:29.441728Z"
+     "iopub.execute_input": "2023-09-16T19:20:19.629043Z",
+     "iopub.status.busy": "2023-09-16T19:20:19.628838Z",
+     "iopub.status.idle": "2023-09-16T19:20:19.633963Z",
+     "shell.execute_reply": "2023-09-16T19:20:19.633208Z"
     },
     "tags": [
      "html_only"
@@ -60,7 +60,7 @@
    "source": [
     "# Introduction\n",
     "\n",
-    "With the advent of quantum computers, [quantum supremacy having been shown](https://www.nature.com/articles/s41586-019-1666-5)<cite data-cite=\"arute2019quantum\"></cite>, [quantum practicality](https://m-cacm.acm.org/magazines/2023/5/272276-disentangling-hype-from-practicality-on-realistically-achieving-quantum-advantage/fulltext)<cite data-cite=\"hoefler2023disentangling\"></cite> only being a decade or so away, and cryptanalytically-relevant quantum computers (CRQC) perhaps to follow shortly behind <cite data-cite=\"biden2022national\"></cite><cite data-cite=\"mattsson2022quantum\"></cite><cite data-cite=\"parker2023estimating\"></cite> <!-- giron2023migrating, parker2023estimating, althobaiti2021quantum -->, NIST is in its [fourth round of looking for post-quantum cryptography algorithms](https://csrc.nist.gov/projects/post-quantum-cryptography)<cite data-cite=\"nistpqc\"></cite>.\n",
+    "With the advent of quantum computers, [quantum supremacy having been shown](https://www.nature.com/articles/s41586-019-1666-5)<cite data-cite=\"arute2019quantum\"></cite>, [quantum practicality](https://m-cacm.acm.org/magazines/2023/5/272276-disentangling-hype-from-practicality-on-realistically-achieving-quantum-advantage/fulltext)<cite data-cite=\"hoefler2023disentangling\"></cite> only being a decade or so away, and cryptanalytically-relevant quantum computers (CRQC) will perhaps follow shortly behind <cite data-cite=\"biden2022national\"></cite><cite data-cite=\"mattsson2022quantum\"></cite><cite data-cite=\"parker2023estimating\"></cite> <!-- giron2023migrating, parker2023estimating, althobaiti2021quantum -->, NIST is in its [fourth round of looking for post-quantum cryptography algorithms](https://csrc.nist.gov/projects/post-quantum-cryptography)<cite data-cite=\"nistpqc\"></cite>.\n",
     "\n",
     "Novel algorithms like [SWOOSH](https://cryptosith.org/papers/swoosh-20230223.pdf)<cite data-cite=\"gajland2023swoosh\"></cite> notwithstanding, no Diffie-Hellman-type algorithms have so far been chosen as [standardization candidates](https://csrc.nist.gov/Projects/post-quantum-cryptography/selected-algorithms-2022)<cite data-cite=\"nistselected\"></cite> but three out of the four announced algorithms <cite data-cite=\"cryptoeprint:2017/634\"></cite><cite data-cite=\"cryptoeprint:2014/903\"></cite><cite data-cite=\"cryptoeprint:2017/633\"></cite><cite data-cite=\"cryptoeprint:2019/1086\"></cite> are Key Encapsulation Mechanisms rather than Key Exchange Mechanisms."
    ]
@@ -95,10 +95,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-09-04T20:55:29.444994Z",
-     "iopub.status.busy": "2023-09-04T20:55:29.444615Z",
-     "iopub.status.idle": "2023-09-04T20:55:29.448961Z",
-     "shell.execute_reply": "2023-09-04T20:55:29.448385Z"
+     "iopub.execute_input": "2023-09-16T19:20:19.637031Z",
+     "iopub.status.busy": "2023-09-16T19:20:19.636840Z",
+     "iopub.status.idle": "2023-09-16T19:20:19.641307Z",
+     "shell.execute_reply": "2023-09-16T19:20:19.640600Z"
     },
     "tags": [
      "latex_only"
@@ -273,10 +273,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-09-04T20:55:29.451570Z",
-     "iopub.status.busy": "2023-09-04T20:55:29.451231Z",
-     "iopub.status.idle": "2023-09-04T20:55:29.458612Z",
-     "shell.execute_reply": "2023-09-04T20:55:29.458070Z"
+     "iopub.execute_input": "2023-09-16T19:20:19.643339Z",
+     "iopub.status.busy": "2023-09-16T19:20:19.643194Z",
+     "iopub.status.idle": "2023-09-16T19:20:19.652013Z",
+     "shell.execute_reply": "2023-09-16T19:20:19.651027Z"
     }
    },
    "outputs": [],
@@ -302,10 +302,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-09-04T20:55:29.460927Z",
-     "iopub.status.busy": "2023-09-04T20:55:29.460712Z",
-     "iopub.status.idle": "2023-09-04T20:55:29.464036Z",
-     "shell.execute_reply": "2023-09-04T20:55:29.463206Z"
+     "iopub.execute_input": "2023-09-16T19:20:19.655079Z",
+     "iopub.status.busy": "2023-09-16T19:20:19.654562Z",
+     "iopub.status.idle": "2023-09-16T19:20:19.657742Z",
+     "shell.execute_reply": "2023-09-16T19:20:19.657191Z"
     }
    },
    "outputs": [],
@@ -325,10 +325,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-09-04T20:55:29.466580Z",
-     "iopub.status.busy": "2023-09-04T20:55:29.466228Z",
-     "iopub.status.idle": "2023-09-04T20:55:29.469953Z",
-     "shell.execute_reply": "2023-09-04T20:55:29.469328Z"
+     "iopub.execute_input": "2023-09-16T19:20:19.659624Z",
+     "iopub.status.busy": "2023-09-16T19:20:19.659405Z",
+     "iopub.status.idle": "2023-09-16T19:20:19.662990Z",
+     "shell.execute_reply": "2023-09-16T19:20:19.662471Z"
     }
    },
    "outputs": [],
@@ -373,10 +373,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-09-04T20:55:29.472384Z",
-     "iopub.status.busy": "2023-09-04T20:55:29.471875Z",
-     "iopub.status.idle": "2023-09-04T20:55:29.513951Z",
-     "shell.execute_reply": "2023-09-04T20:55:29.513284Z"
+     "iopub.execute_input": "2023-09-16T19:20:19.664744Z",
+     "iopub.status.busy": "2023-09-16T19:20:19.664500Z",
+     "iopub.status.idle": "2023-09-16T19:20:19.700771Z",
+     "shell.execute_reply": "2023-09-16T19:20:19.699456Z"
     }
    },
    "outputs": [],
@@ -405,10 +405,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-09-04T20:55:29.516182Z",
-     "iopub.status.busy": "2023-09-04T20:55:29.515989Z",
-     "iopub.status.idle": "2023-09-04T20:55:29.519821Z",
-     "shell.execute_reply": "2023-09-04T20:55:29.519244Z"
+     "iopub.execute_input": "2023-09-16T19:20:19.703534Z",
+     "iopub.status.busy": "2023-09-16T19:20:19.703228Z",
+     "iopub.status.idle": "2023-09-16T19:20:19.708076Z",
+     "shell.execute_reply": "2023-09-16T19:20:19.707326Z"
     }
    },
    "outputs": [],
@@ -478,10 +478,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-09-04T20:55:29.522101Z",
-     "iopub.status.busy": "2023-09-04T20:55:29.521784Z",
-     "iopub.status.idle": "2023-09-04T20:55:29.525465Z",
-     "shell.execute_reply": "2023-09-04T20:55:29.524858Z"
+     "iopub.execute_input": "2023-09-16T19:20:19.710481Z",
+     "iopub.status.busy": "2023-09-16T19:20:19.710165Z",
+     "iopub.status.idle": "2023-09-16T19:20:19.713502Z",
+     "shell.execute_reply": "2023-09-16T19:20:19.712917Z"
     }
    },
    "outputs": [],
@@ -518,10 +518,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-09-04T20:55:29.528185Z",
-     "iopub.status.busy": "2023-09-04T20:55:29.527881Z",
-     "iopub.status.idle": "2023-09-04T20:55:29.533550Z",
-     "shell.execute_reply": "2023-09-04T20:55:29.533023Z"
+     "iopub.execute_input": "2023-09-16T19:20:19.715549Z",
+     "iopub.status.busy": "2023-09-16T19:20:19.715387Z",
+     "iopub.status.idle": "2023-09-16T19:20:19.721513Z",
+     "shell.execute_reply": "2023-09-16T19:20:19.720841Z"
     }
    },
    "outputs": [],
@@ -602,10 +602,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-09-04T20:55:29.535898Z",
-     "iopub.status.busy": "2023-09-04T20:55:29.535330Z",
-     "iopub.status.idle": "2023-09-04T20:55:29.539663Z",
-     "shell.execute_reply": "2023-09-04T20:55:29.539084Z"
+     "iopub.execute_input": "2023-09-16T19:20:19.723343Z",
+     "iopub.status.busy": "2023-09-16T19:20:19.723147Z",
+     "iopub.status.idle": "2023-09-16T19:20:19.727377Z",
+     "shell.execute_reply": "2023-09-16T19:20:19.726858Z"
     },
     "tags": [
      "latex_only"
@@ -629,10 +629,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-09-04T20:55:29.541957Z",
-     "iopub.status.busy": "2023-09-04T20:55:29.541412Z",
-     "iopub.status.idle": "2023-09-04T20:55:29.545976Z",
-     "shell.execute_reply": "2023-09-04T20:55:29.545313Z"
+     "iopub.execute_input": "2023-09-16T19:20:19.729239Z",
+     "iopub.status.busy": "2023-09-16T19:20:19.729021Z",
+     "iopub.status.idle": "2023-09-16T19:20:19.732867Z",
+     "shell.execute_reply": "2023-09-16T19:20:19.732055Z"
     },
     "tags": [
      "latex_only"
@@ -709,7 +709,7 @@
     "\n",
     "In part due to these considerations, DNP3-SAv6 relies heavily on symmetric cryptography, for which hardware acceleration is ubiquitously available and which remains secure in the presence of adversaries with quantum computers. This again constrains the use of a PQC to the Association handshake and may partly drive the choice of both the algorithms to use and on which device (the master or the outstation) key encapsulation takes place. While M. Kumar's survey of post-quantum peformance in <cite data-cite=\"kumar2022post\">\"Post-quantum cryptography Algorithm's standardization and performance analysis\", Array 15, 2022</cite> shows, perhaps surprisingly (at least to me) encapsulating keys can be significantly less costly than decapsulating them, in which case it would make sense to perform encapsulating on the outstation, it may be too early to tell whether that will be true for all KEM standards, so it would be advisable to leave the door open to performing encapsulation on the master when needed.\n",
     "\n",
-    "Additionally, it should be noted that, as DNP3-SAv6 supports both mutual authentication and data encryption and, once the association is established, does not require asymmetric cryptography for subsequent sessions that nevertheless retain both mutual authentication and data encryption, the additional overhead a TLS connection would require for its sessions (which have their own asymmetric cryptography for every session) becomes unnecessary. I therefore see no reason to recommend using TLS in conjunction with DNP3, and in some cases would actually recommend against it, especially when communicating with resource-constrained devices that are part of critical infrastructure."
+    "Additionally, it should be noted that, as DNP3-SAv6 supports both mutual authentication and data encryption and, once the association is established, does not require asymmetric cryptography for subsequent sessions that nevertheless retain both mutual authentication and data encryption, the additional overhead a TLS connection would require for its sessions becomes unnecessary. (TLS connections have their own asymmetric cryptography for every session unless the PSK mode is used. The PSK mode is disallowed by IEC 62351-3, which applies in most situation where DNP3 would be used.) I therefore see no reason to recommend using TLS in conjunction with DNP3, and in some cases would actually recommend against it, especially when communicating with resource-constrained devices that are part of critical infrastructure."
    ]
   },
   {
@@ -774,10 +774,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-09-04T20:55:29.548304Z",
-     "iopub.status.busy": "2023-09-04T20:55:29.547951Z",
-     "iopub.status.idle": "2023-09-04T20:55:29.551927Z",
-     "shell.execute_reply": "2023-09-04T20:55:29.551326Z"
+     "iopub.execute_input": "2023-09-16T19:20:19.735922Z",
+     "iopub.status.busy": "2023-09-16T19:20:19.735284Z",
+     "iopub.status.idle": "2023-09-16T19:20:19.740864Z",
+     "shell.execute_reply": "2023-09-16T19:20:19.740159Z"
     },
     "tags": [
      "latex_only"

--- a/paper.ipynb
+++ b/paper.ipynb
@@ -60,7 +60,7 @@
    "source": [
     "# Introduction\n",
     "\n",
-    "With the advent of quantum computers, [quantum supremacy having been shown](https://www.nature.com/articles/s41586-019-1666-5)<cite data-cite=\"arute2019quantum\"></cite>, [quantum practicality](https://m-cacm.acm.org/magazines/2023/5/272276-disentangling-hype-from-practicality-on-realistically-achieving-quantum-advantage/fulltext)<cite data-cite=\"hoefler2023disentangling\"></cite> only being a decade or so away, and cryptanalytically-relevant quantum computers (CRQC) likey to follow shortly behind [**citation needed**], NIST is in its [fourth round of looking for post-quantum cryptography algorithms](https://csrc.nist.gov/projects/post-quantum-cryptography)<cite data-cite=\"nistpqc\"></cite>.\n",
+    "With the advent of quantum computers, [quantum supremacy having been shown](https://www.nature.com/articles/s41586-019-1666-5)<cite data-cite=\"arute2019quantum\"></cite>, [quantum practicality](https://m-cacm.acm.org/magazines/2023/5/272276-disentangling-hype-from-practicality-on-realistically-achieving-quantum-advantage/fulltext)<cite data-cite=\"hoefler2023disentangling\"></cite> only being a decade or so away, and cryptanalytically-relevant quantum computers (CRQC) perhaps to follow shortly behind <cite data-cite=\"biden2022national\"></cite><cite data-cite=\"mattsson2022quantum\"></cite><cite data-cite=\"parker2023estimating\"></cite> <!-- giron2023migrating, parker2023estimating, althobaiti2021quantum -->, NIST is in its [fourth round of looking for post-quantum cryptography algorithms](https://csrc.nist.gov/projects/post-quantum-cryptography)<cite data-cite=\"nistpqc\"></cite>.\n",
     "\n",
     "Novel algorithms like [SWOOSH](https://cryptosith.org/papers/swoosh-20230223.pdf)<cite data-cite=\"gajland2023swoosh\"></cite> notwithstanding, no Diffie-Hellman-type algorithms have so far been chosen as [standardization candidates](https://csrc.nist.gov/Projects/post-quantum-cryptography/selected-algorithms-2022)<cite data-cite=\"nistselected\"></cite> but three out of the four announced algorithms <cite data-cite=\"cryptoeprint:2017/634\"></cite><cite data-cite=\"cryptoeprint:2014/903\"></cite><cite data-cite=\"cryptoeprint:2017/633\"></cite><cite data-cite=\"cryptoeprint:2019/1086\"></cite> are Key Encapsulation Mechanisms rather than Key Exchange Mechanisms."
    ]
@@ -792,7 +792,10 @@
     "\\nocite{kwiatkowski2019measuring}\n",
     "\\nocite{malina2018feasibility}\n",
     "\\nocite{kumar2022post}\n",
-    "\\nocite{kampanakis2018viability}"
+    "\\nocite{kampanakis2018viability}\n",
+    "\\nocite{giron2023migrating}\n",
+    "\\nocite{parker2023estimating}\n",
+    "\\nocite{althobaiti2021quantum}"
    ]
   }
  ],

--- a/paper.ipynb
+++ b/paper.ipynb
@@ -5,10 +5,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-08-04T05:58:20.098892Z",
-     "iopub.status.busy": "2023-08-04T05:58:20.098479Z",
-     "iopub.status.idle": "2023-08-04T05:58:20.115714Z",
-     "shell.execute_reply": "2023-08-04T05:58:20.114170Z"
+     "iopub.execute_input": "2023-09-04T20:55:29.406588Z",
+     "iopub.status.busy": "2023-09-04T20:55:29.405942Z",
+     "iopub.status.idle": "2023-09-04T20:55:29.414013Z",
+     "shell.execute_reply": "2023-09-04T20:55:29.413158Z"
     },
     "tags": [
      "html_only"
@@ -34,10 +34,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-08-04T05:58:20.156132Z",
-     "iopub.status.busy": "2023-08-04T05:58:20.155762Z",
-     "iopub.status.idle": "2023-08-04T05:58:20.162600Z",
-     "shell.execute_reply": "2023-08-04T05:58:20.161620Z"
+     "iopub.execute_input": "2023-09-04T20:55:29.437912Z",
+     "iopub.status.busy": "2023-09-04T20:55:29.437682Z",
+     "iopub.status.idle": "2023-09-04T20:55:29.442394Z",
+     "shell.execute_reply": "2023-09-04T20:55:29.441728Z"
     },
     "tags": [
      "html_only"
@@ -60,7 +60,7 @@
    "source": [
     "# Introduction\n",
     "\n",
-    "With the advent of quantum computers, [quantum supremacy having been shown](https://www.nature.com/articles/s41586-019-1666-5)<cite data-cite=\"arute2019quantum\"></cite> and [quantum practicality](https://m-cacm.acm.org/magazines/2023/5/272276-disentangling-hype-from-practicality-on-realistically-achieving-quantum-advantage/fulltext)<cite data-cite=\"hoefler2023disentangling\"></cite> only being a decade or so away, NIST is in its [fourth round of looking for post-quantum cryptography algorithms](https://csrc.nist.gov/projects/post-quantum-cryptography)<cite data-cite=\"nistpqc\"></cite>.\n",
+    "With the advent of quantum computers, [quantum supremacy having been shown](https://www.nature.com/articles/s41586-019-1666-5)<cite data-cite=\"arute2019quantum\"></cite>, [quantum practicality](https://m-cacm.acm.org/magazines/2023/5/272276-disentangling-hype-from-practicality-on-realistically-achieving-quantum-advantage/fulltext)<cite data-cite=\"hoefler2023disentangling\"></cite> only being a decade or so away, and cryptanalytically-relevant quantum computers (CRQC) likey to follow shortly behind [**citation needed**], NIST is in its [fourth round of looking for post-quantum cryptography algorithms](https://csrc.nist.gov/projects/post-quantum-cryptography)<cite data-cite=\"nistpqc\"></cite>.\n",
     "\n",
     "Novel algorithms like [SWOOSH](https://cryptosith.org/papers/swoosh-20230223.pdf)<cite data-cite=\"gajland2023swoosh\"></cite> notwithstanding, no Diffie-Hellman-type algorithms have so far been chosen as [standardization candidates](https://csrc.nist.gov/Projects/post-quantum-cryptography/selected-algorithms-2022)<cite data-cite=\"nistselected\"></cite> but three out of the four announced algorithms <cite data-cite=\"cryptoeprint:2017/634\"></cite><cite data-cite=\"cryptoeprint:2014/903\"></cite><cite data-cite=\"cryptoeprint:2017/633\"></cite><cite data-cite=\"cryptoeprint:2019/1086\"></cite> are Key Encapsulation Mechanisms rather than Key Exchange Mechanisms."
    ]
@@ -76,7 +76,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This paper aims to fill that gap by contributing three things: first, I present an analysis on how DH and KEM differ, and how a KEM can be built using a DH. The purpose of this is to allow framing the question in terms of the DH construct, which is generally more familiar to members of the OT-cyber community. It also allows experimenting with tools we have at hand without needing to modify existing libraries such as OpenSSL. Second, I present lessons from experiments with TLS found in the existing literature, as applicable to the DNP3-SAv6 and IEC 62351-5 protocols. Finally, I present proposed changes to DNP3-SAv6, as presented to the DNP CSTF at the time of this writing, with their background reasoning."
+    "This paper aims to fill that gap by contributing three things: first, I present an analysis on how DH and KEM differ, and how a KEM can be notationally expressed in terms of a DH. The purpose of this is to allow framing the question in terms of the DH construct, which is generally more familiar to members of the OT-cyber community. It also allows experimenting with tools we have at hand without needing to modify existing libraries such as OpenSSL. Second, I present lessons from experiments with TLS found in the existing literature, as applicable to the DNP3-SAv6 and IEC 62351-5 protocols. Finally, I present proposed changes to DNP3-SAv6, as presented to the DNP CSTF at the time of this writing, with their background reasoning."
    ]
   },
   {
@@ -95,10 +95,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-08-04T05:58:20.165685Z",
-     "iopub.status.busy": "2023-08-04T05:58:20.165459Z",
-     "iopub.status.idle": "2023-08-04T05:58:20.173084Z",
-     "shell.execute_reply": "2023-08-04T05:58:20.171927Z"
+     "iopub.execute_input": "2023-09-04T20:55:29.444994Z",
+     "iopub.status.busy": "2023-09-04T20:55:29.444615Z",
+     "iopub.status.idle": "2023-09-04T20:55:29.448961Z",
+     "shell.execute_reply": "2023-09-04T20:55:29.448385Z"
     },
     "tags": [
      "latex_only"
@@ -121,9 +121,11 @@
    "source": [
     "# What is a KEM?\n",
     "\n",
-    "A KEM is used, as the name implies, to encapsulate a (symmetric) key in order to securely send it to someone else. As it's an asymmetric cryptography algorithm, you need the other person's public key to do this but, unlike key exchange algorithms, the other person does not need your public key to receive the symmetric key and, unlike digital signature algorithms and key exchange algorithms, the recipient cannot authenticate the received key with only this mechanism.\n",
+    "A KEM is used, as the name implies, to encapsulate a (symmetric) key in order to securely send it to someone else. As it's an asymmetric cryptography algorithm, you need the other person's public key to do this but, unlike key exchange algorithms, the other person does not need your public key to receive the symmetric key and, unlike digital signature algorithms and key exchange algorithms, the recipient cannot authenticate the received key with only a singge use of this mechanism.\n",
     "\n",
-    "This is actually one of the oldest applications of RSA besides digital signatures: because RSA allows things encrypted with a public key to be  decrypted with the corresponding private key as well as allowing  something encrypted with a private key to be decrypted with the corresponding public key, it can be used both for key encapsulation and signatures."
+    "This is actually one of the oldest applications of RSA besides digital signatures: because RSA allows things encrypted with a public key to be decrypted with the corresponding private key as well as allowing  something encrypted with a private key to be decrypted with the corresponding public key, it can be used both for key encapsulation and signatures.\n",
+    "\n",
+    "There are three use-cases for KEM, all three discussed below. The first is a simple key encapsulation, where Alice sends a message to Bob, ascertaining only Bob can receive it, but Bob cannot authenticate the message as being from Alice, and without providing forward secrecy. The second is called \"Unilateral Authenticated Key Exchange\" or UAKE, where Alice sends a message to Bob, ascertaining only Bob can receive it, but Bob can still not authenticate the message as being from Alice; this time providing forward secrecy but requiring messages to be exchanged in both directions for the key exchange to occur. The third, called \"Authenticated Key Exchange\" or AKE, allows Alice and Bob to mutually authenticate and also provides forward secrecy, also requiring messages to be exchanged in both directions. This latter use-case is closest to the DH use-case, but unlike DH does not allow for an off-line mutually authenticated key exchange."
    ]
   },
   {
@@ -134,7 +136,7 @@
     "\n",
     "The KEM API consists of three functions:\n",
     "\n",
-    "- keypair generation: $G \\rightarrow \\langle sk,pk\\rangle$ generates a key pair $\\langle sk,pk\\rangle$ where $sk$ is the private key and $pk$ is the public key.\n",
+    "- keypair generation: $G \\rightarrow \\langle sk,pk\\rangle$ generates a key pair $\\langle sk,pk\\rangle$ where $sk$ is the private key and $pk$ is the public key. This function takes no parameters.\n",
     "- encrypting: $E \\rightarrow pk \\rightarrow \\langle s,ct \\rangle$ takes the public key $pk$ and generates a random shared secret $s$ and the corresponding ciphertext $ct$. Due to the way the API is specified (which is essentially the smallest common denominator for these types of algorithms) the user has no control over the value of the shared secret. We will exploit this fact in our simulation.\n",
     "- decrypting: $D \\rightarrow sk \\rightarrow ct \\rightarrow s$ takes the private key $sk$ and the ciphertext $ct$ and produces the shared secret, which is identical to the one generated by $E$.\n",
     "\n",
@@ -145,17 +147,66 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## KEM use case\n",
+    "## KEM use cases\n",
     "\n",
-    "The typical use case for a key encapsulation is the same as for a key exchange: Alice wants to send a message to Bob and doesn't want Eve to be able to eavesdrop. To do this:\n",
+    "The typical use case for a key encapsulation is the same as for a key exchange: Alice wants to send a message to Bob and doesn't want Eve to be able to eavesdrop. Assuming Alice at least has Bob's public key, Alice has three options:\n",
     "\n",
-    "1. Bob generates a key pair (private key and public key) and securely provisions his public key to Alice (i.e. she can authenticate it). More formally, Bob performs $\\langle sk, pk \\rangle = G$, then signs $pk$ and sends it to Alice.\n",
-    "2. Alice uses Bob's public key to generate a shared secret and a ciphertext. She then encrypts her message with that derived key using an AEAD. She then signs the key ciphertext and the encrypted message and sends it all to Bob. More formally, she sends $\\langle m', ct, signature\\rangle$ where $m'$ is the encrypted message and $ct$ is the ciphertext of the random key.\n",
-    "3. Bob receives the message, verifies the signature, decrypts the ciphertext using his private key and thus obtains  the same shared secret as Alice, and uses that the decrypt the message. \n",
+    "1. She can perform a straight key exchange (KE), which allows her to send a key to Bob knowing only Bob can decrypt it, but does not provide any forward secrecy. She does not have to receive any messages from Bob to do this (she already has his public key), and Bob does not need her public key.\n",
+    "2. She can perform a \"Unilaterally Authenticated Key Exchange\" (UAKE), which allows her to send a message to Bob knowing only Bob can decrypt it, and provides limited forward secrecy. She does need to send a message to Bob and receive a response for this, in addition to the public key she already has. Bob does not need her public key.\n",
+    "3. She can perform an \"Authenticated Key Exchange\" (AKE). This allows her to send a message to Bob knowing only Bob decrypt it, but additionally allows Bob to authenticate the message as being from Alice. Alice and Bob need to exchange messages for this, similar to the UAKE case, but this does provide both mutual authentication and limited forward secrecy.\n",
+    "\n",
+    "KEM does not have an option that provides mutual authentication without limited forward secrecy, like DH does. It is possible to construct a mutually-authenticated key exchange with perfect forward secrecy using only KEM, but that requires a ciphertext to be sent along with the encrypted message. This fourth construct is left as an exercise to the reader."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### KEM Key Exchange (KE): unilateral authentication, no forward secrecy, off-line\n",
+    "\n",
+    "Alice can send an unauthenticated message to Bob, without requiring any on-line message exchanges with Bob, but still making sure only Bob can read the message. To do this:\n",
+    "\n",
+    "1. Bob generates a key pair (private key and public key) and securely provisions his public key to Alice (i.e. she can authenticate it). More formally, Bob performs $\\langle sk, pk \\rangle \\leftarrow G$, then signs $pk$ and sends it to Alice.\n",
+    "2. Alice uses Bob's public key to generate a shared secret and a ciphertext ($ct, s \\leftarrow E~pk$). She then encrypts her message with that derived key using an AEAD.\n",
+    "3. Bob receives the message, decrypts the ciphertext using his private key and thus obtains the same shared secret as Alice, and uses that to the decrypt the message. \n",
     "\n",
     "Eve will only have seen the public key and ciphertext, and thus has no feasible way to recover the shared secret or the message.\n",
     "\n",
-    "Note that the signatures above require a separate digital signature algorithm, not provided by KEM itself."
+    "Note that this approach does not allow Bob to authenticate Alice's message. For that, she either has to use the AKE approach described below, of use a DSA to sign the message and the ciphertext.\n",
+    "\n",
+    "Also note that, because no ephemeral keys are used here, if Eve ever obtains Bob's private key she can decrypt every message Alice ever sent to Bob."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### KEM Unilaterally Authenticated Key Exchange (UAKE): unilateral authentication, limited forward secrecy, on-line\n",
+    "\n",
+    "Alice can send an unauthenticated message to Bob, making sure that only Bob can read it, and making sure that even if Eve obtains Alice's (ephemeral) private key, she won't be able to decrypt every message Alice ever sent to Bob (provided she doesn't use the same ephemeral key pair every time she sends a message to Bob). Eve will still be able to do that if she obtains Bob's private key. To do this:\n",
+    "\n",
+    "1. Bob generates a key pair (private key and public key) and securely provisions his public key to Alice (i.e. she can authenticate it). More formally, Bob performs $\\langle sk_B, pk_B \\rangle \\leftarrow G$, then signs $pk_B$ and sends it to Alice.\n",
+    "2. Alice generates an *ephemeral* key pair $\\langle sk_A, pk_A \\rangle \\leftarrow G$ and a ciphertext and shared secret $\\langle s_1, ct_1 \\rangle \\leftarrow E~pk_B$ and sends $\\langle pk_A, ct_1 \\rangle$ to Bob.\n",
+    "3. Bob receives $\\langle pk_A, ct_1 \\rangle$, decapsulates the ciphertext to get the shared secret $s_1' \\leftarrow D~sk_B~ct_1$ and generates a ciphertext and shared secret from Alice's ephemeral public key: $\\langle s_2, ct_2 \\rangle \\leftarrow E~pk_A$. He then sends back the new ciphertext $ct_2$. Bob can now use a pre-agreed combination function $H$ to combine $s_1'$ and $s_2$ into a shared secret $k \\leftarrow H~s_1'~s_2$.\n",
+    "4. Alice receives $ct_2$ and decapsulates it using her ephemeral private key $s_2' \\leftarrow D~sk_A~ ct_2$. Alice can now use the same pre-agreed combination function $H$ to combine $s_1$ and $s_2'$ into the same shared secret $k' \\leftarrow H~s_1~s_2'$, after which $k = k'$. She can then use the new key $k$ to encrypt her message.\n",
+    "\n",
+    "Note that this means Alice and Bob have to exchange two messages (one in each direction) to set up these keys, and only Bob is authenticated at this point. If Alice wants to authenticate herself to Bob, she needs to either use the AKE mechanism explained below, or use a DSA algorithm.\n",
+    "\n",
+    "This method does use an ephemeral key, but only from Alice: if Eve were to obtain Bob's private key, she would still be able to decrypt every message ever sent to Bob, provided she kept the transcripts (which contain the public keys used by Alice).\n",
+    "\n",
+    "### KEM Authenticated Key Exchange (AKE): mutual authentication, limited forward secrecy, on-line\n",
+    "\n",
+    "Alice can send an authenticated message to Bob, making sure only Bob can read it, and making sure Eve would have to know both Alice and Bob's private keys to decrypt messages exchanged between the two. To do this:\n",
+    "\n",
+    "1. Bob generates a key pair (private key and public key) and securely provisions his public key to Alice (i.e. she can authenticate it). More formally, Bob performs $\\langle sk_B, pk_B \\rangle \\leftarrow G$, then signs $pk_B$ and sends it to Alice.\n",
+    "2. Alice generates a key pair (private key and public key) and securely provisions her public key to Bob (i.e. he can authenticate it). More formally, Alice performs $\\langle sk_A, pk_A \\rangle \\leftarrow G$, then signs $pk_A$ and sends it to Bob. Note that she *could* send her key to Bob at the same time she sends the next message (below).\n",
+    "3. Alice generates an *ephemeral* key pair $\\langle sk_{A*}, pk_{A*} \\rangle \\leftarrow G$ and a ciphertext and shared secret $\\langle s_1, ct_1 \\rangle \\leftarrow E~pk_B$ and sends $\\langle pk_{A*}, ct_1 \\rangle$ to Bob.\n",
+    "4. Bob receives $\\langle pk_{A*}, ct_1 \\rangle$, decapsulates the ciphertext to get the shared secret $s_1' \\leftarrow D~sk_B~ct_1$, encapsulates a first secret using the just-received ephemeral public key $\\langle s_2, ct_2 \\rangle \\leftarrow E~pk_{A*}$ and a second secret using Alice's static key $\\langle s_3, ct_3 \\rangle \\leftarrow E~pk_{A}$. He now has three shared secrets, $s_1'$, $s_2$, and $s_3$ which he can combine using a pre-agreed function $H$ into a single shared secret $k \\leftarrow H~s_1'~s_2~s_3$. He sends $\\langle c_2, c_3 \\rangle$ to Alice.\n",
+    "5. Alice receives $\\langle c_2, c_3 \\rangle$ and decapsulates them using her ephemeral and static private keys, resp.: $s_2' \\leftarrow D~sk_{A*}~ct_2$, and $s_3' \\leftarrow D~sk_{A*}~ct_3$. She now has the same three shared secrets, $s_1$, $s_2'$, and $s_3'$ which she can combine using a pre-agreed function $H$ int a single shared secret $k' \\leftarrow H~s_1~s_2'~s_3'$. Now, $k = k'$, so Alice can encrypt her message using this key.\n",
+    "\n",
+    "With this approach, Alice and Bob have to exchange two messages, one in each direction, but they get mutual authentication and limited forward secrecy.\n",
+    "\n",
+    "Like UAKE, this method does use an ephemeral key, but only from Alice: if Eve were to obtain Bob's private key, she would still be able to decrypt every message ever sent to Bob, provided she kept the transcripts (which contain the public keys used by Alice).\n"
    ]
   },
   {
@@ -166,9 +217,11 @@
     "\n",
     "The use case between a KEM and a DH is very similar: in both cases, Alice and Bob want to establish a symmetric key to use in communications. In the case of a DH, this happens by Alice and Bob exchanging their respective public keys, and each using their respective private keys and each others' public keys.\n",
     "\n",
-    "While that use case is similar, there are significant differences: KEM does not provide mutual authentication where DH does, which means KEM requires the use of a separate digital signature algorithm: DH also requires the use of a signature algorithm, but only during public key exchanges while KEM requires it every time a new shared key is generated.\n",
+    "While that use case is similar, there are significant differences: KEM does not provide *offline* mutually authenticated key exchange where DH does, which means KEM requires the use of a separate digital signature algorithm if it to be used in an offline mode for mutual authentication. To use only a KEM algorithm for a mutually authenticated key exchange, at least two messages need to be exchanged and the algorithm is used three times on either side (Alice encapsulates once and decapsulates twice; Bob encapsulates twice and decapsulates once).\n",
     "\n",
-    "Similarly to KEM, DH does not allow its user any influence over the contents of the symmetric key. Also, because with the use of the same keys the resulting shared secret is always the same, it is recommended to always include a salting step (generally in the form of a publicly-communicated salt and an HKDF function). This is not required in the case of a KEM."
+    "Similarly to KEM, DH does not allow its user any influence over the contents of the symmetric key. Also, because with the use of the same keys the resulting shared secret is always the same, it is recommended to always include a salting step (generally in the form of a publicly-communicated salt and an HKDF function). This is not required in the case of a KEM.\n",
+    "\n",
+    "Neither DH not KEM provide perfect forward secrecy using static keys."
    ]
   },
   {
@@ -218,10 +271,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-08-04T05:58:20.176708Z",
-     "iopub.status.busy": "2023-08-04T05:58:20.176468Z",
-     "iopub.status.idle": "2023-08-04T05:58:20.188214Z",
-     "shell.execute_reply": "2023-08-04T05:58:20.186957Z"
+     "iopub.execute_input": "2023-09-04T20:55:29.451570Z",
+     "iopub.status.busy": "2023-09-04T20:55:29.451231Z",
+     "iopub.status.idle": "2023-09-04T20:55:29.458612Z",
+     "shell.execute_reply": "2023-09-04T20:55:29.458070Z"
     }
    },
    "outputs": [],
@@ -247,10 +300,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-08-04T05:58:20.191584Z",
-     "iopub.status.busy": "2023-08-04T05:58:20.191292Z",
-     "iopub.status.idle": "2023-08-04T05:58:20.196934Z",
-     "shell.execute_reply": "2023-08-04T05:58:20.195217Z"
+     "iopub.execute_input": "2023-09-04T20:55:29.460927Z",
+     "iopub.status.busy": "2023-09-04T20:55:29.460712Z",
+     "iopub.status.idle": "2023-09-04T20:55:29.464036Z",
+     "shell.execute_reply": "2023-09-04T20:55:29.463206Z"
     }
    },
    "outputs": [],
@@ -270,10 +323,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-08-04T05:58:20.200052Z",
-     "iopub.status.busy": "2023-08-04T05:58:20.199803Z",
-     "iopub.status.idle": "2023-08-04T05:58:20.205975Z",
-     "shell.execute_reply": "2023-08-04T05:58:20.204845Z"
+     "iopub.execute_input": "2023-09-04T20:55:29.466580Z",
+     "iopub.status.busy": "2023-09-04T20:55:29.466228Z",
+     "iopub.status.idle": "2023-09-04T20:55:29.469953Z",
+     "shell.execute_reply": "2023-09-04T20:55:29.469328Z"
     }
    },
    "outputs": [],
@@ -318,10 +371,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-08-04T05:58:20.209034Z",
-     "iopub.status.busy": "2023-08-04T05:58:20.208801Z",
-     "iopub.status.idle": "2023-08-04T05:58:20.306134Z",
-     "shell.execute_reply": "2023-08-04T05:58:20.304805Z"
+     "iopub.execute_input": "2023-09-04T20:55:29.472384Z",
+     "iopub.status.busy": "2023-09-04T20:55:29.471875Z",
+     "iopub.status.idle": "2023-09-04T20:55:29.513951Z",
+     "shell.execute_reply": "2023-09-04T20:55:29.513284Z"
     }
    },
    "outputs": [],
@@ -350,10 +403,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-08-04T05:58:20.311954Z",
-     "iopub.status.busy": "2023-08-04T05:58:20.311016Z",
-     "iopub.status.idle": "2023-08-04T05:58:20.317016Z",
-     "shell.execute_reply": "2023-08-04T05:58:20.315980Z"
+     "iopub.execute_input": "2023-09-04T20:55:29.516182Z",
+     "iopub.status.busy": "2023-09-04T20:55:29.515989Z",
+     "iopub.status.idle": "2023-09-04T20:55:29.519821Z",
+     "shell.execute_reply": "2023-09-04T20:55:29.519244Z"
     }
    },
    "outputs": [],
@@ -423,10 +476,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-08-04T05:58:20.321436Z",
-     "iopub.status.busy": "2023-08-04T05:58:20.321167Z",
-     "iopub.status.idle": "2023-08-04T05:58:20.326825Z",
-     "shell.execute_reply": "2023-08-04T05:58:20.325761Z"
+     "iopub.execute_input": "2023-09-04T20:55:29.522101Z",
+     "iopub.status.busy": "2023-09-04T20:55:29.521784Z",
+     "iopub.status.idle": "2023-09-04T20:55:29.525465Z",
+     "shell.execute_reply": "2023-09-04T20:55:29.524858Z"
     }
    },
    "outputs": [],
@@ -463,10 +516,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-08-04T05:58:20.329864Z",
-     "iopub.status.busy": "2023-08-04T05:58:20.329626Z",
-     "iopub.status.idle": "2023-08-04T05:58:20.339388Z",
-     "shell.execute_reply": "2023-08-04T05:58:20.338364Z"
+     "iopub.execute_input": "2023-09-04T20:55:29.528185Z",
+     "iopub.status.busy": "2023-09-04T20:55:29.527881Z",
+     "iopub.status.idle": "2023-09-04T20:55:29.533550Z",
+     "shell.execute_reply": "2023-09-04T20:55:29.533023Z"
     }
    },
    "outputs": [],
@@ -547,10 +600,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-08-04T05:58:20.343916Z",
-     "iopub.status.busy": "2023-08-04T05:58:20.342877Z",
-     "iopub.status.idle": "2023-08-04T05:58:20.349185Z",
-     "shell.execute_reply": "2023-08-04T05:58:20.348202Z"
+     "iopub.execute_input": "2023-09-04T20:55:29.535898Z",
+     "iopub.status.busy": "2023-09-04T20:55:29.535330Z",
+     "iopub.status.idle": "2023-09-04T20:55:29.539663Z",
+     "shell.execute_reply": "2023-09-04T20:55:29.539084Z"
     },
     "tags": [
      "latex_only"
@@ -574,10 +627,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-08-04T05:58:20.352701Z",
-     "iopub.status.busy": "2023-08-04T05:58:20.352122Z",
-     "iopub.status.idle": "2023-08-04T05:58:20.358913Z",
-     "shell.execute_reply": "2023-08-04T05:58:20.357687Z"
+     "iopub.execute_input": "2023-09-04T20:55:29.541957Z",
+     "iopub.status.busy": "2023-09-04T20:55:29.541412Z",
+     "iopub.status.idle": "2023-09-04T20:55:29.545976Z",
+     "shell.execute_reply": "2023-09-04T20:55:29.545313Z"
     },
     "tags": [
      "latex_only"
@@ -719,10 +772,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-08-04T05:58:20.362818Z",
-     "iopub.status.busy": "2023-08-04T05:58:20.362546Z",
-     "iopub.status.idle": "2023-08-04T05:58:20.368618Z",
-     "shell.execute_reply": "2023-08-04T05:58:20.367539Z"
+     "iopub.execute_input": "2023-09-04T20:55:29.548304Z",
+     "iopub.status.busy": "2023-09-04T20:55:29.547951Z",
+     "iopub.status.idle": "2023-09-04T20:55:29.551927Z",
+     "shell.execute_reply": "2023-09-04T20:55:29.551326Z"
     },
     "tags": [
      "latex_only"

--- a/paper.ipynb
+++ b/paper.ipynb
@@ -155,7 +155,9 @@
     "2. She can perform a \"Unilaterally Authenticated Key Exchange\" (UAKE), which allows her to send a message to Bob knowing only Bob can decrypt it, and provides limited forward secrecy. She does need to send a message to Bob and receive a response for this, in addition to the public key she already has. Bob does not need her public key.\n",
     "3. She can perform an \"Authenticated Key Exchange\" (AKE). This allows her to send a message to Bob knowing only Bob decrypt it, but additionally allows Bob to authenticate the message as being from Alice. Alice and Bob need to exchange messages for this, similar to the UAKE case, but this does provide both mutual authentication and limited forward secrecy.\n",
     "\n",
-    "KEM does not have an option that provides mutual authentication without limited forward secrecy, like DH does. It is possible to construct a mutually-authenticated key exchange with perfect forward secrecy using only KEM, but that requires a ciphertext to be sent along with the encrypted message. This fourth construct is left as an exercise to the reader."
+    "KEM does not have an option that provides mutual authentication without limited forward secrecy, like DH does. It is possible to construct a mutually-authenticated key exchange with perfect forward secrecy using only KEM, but that requires a ciphertext to be sent along with the encrypted message. This fourth construct is left as an exercise to the reader.\n",
+    "\n",
+    "The three constructs above are each described in Bos et al. <cite data-cite=\"cryptoeprint:2017/634\">\"CRYSTALS -- Kyber: a CCA-secure module-lattice-based KEM\", Cryptology ePrint Archive, Paper 2017/634</cite>, and described below."
    ]
   },
   {


### PR DESCRIPTION
Integrated comments from reviews by the CSTF and Tom Carroll from PNNL (with my thanks)

- Added a reference to CRQC in the introduction. This is honestly a bit of a murky subject to me, with the literature pointing both to it being imminent and nowhere within our reach, so my wording (CRQC "will perhaps follow shortly behind" quantum practicality) reflects that.
- Changed the wording from "building a KEM using DH" to "notationally expressing" in the introduction.
- Clarified some of the pseudo-Haskell to use \leftarrow rather than an equals sign when values are being assigned
- Added explanations of KEM use-cases, including UAKE and AKE. I agree that I was being unfair with KEM, but I'm not entirely sure that adding these actually clarifies the difference between what a KEM can do and what a DH can do. I may come back to this in future iterations.
- Added some notes on forward secrecy. More to come on that: I have a yellowpad with plenty of notes on how to do a mutually authenticated handshake that provides perfect forward secrecy using only KEM.
- Added a reference to IEC 62351-3 to my comment about TLS causing more overhead when re-establishing sessions than SAv6 needs.